### PR TITLE
Update for MongoDB SCRAM-SHA-1 support (3.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.mongodb.morphia</groupId>
             <artifactId>morphia</artifactId>
-            <version>0.108</version>
+            <version>0.111</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/com/graylog2/inputs/mongoprofiler/input/mongodb/MongoDBProfilerTransport.java
+++ b/src/main/java/com/graylog2/inputs/mongoprofiler/input/mongodb/MongoDBProfilerTransport.java
@@ -103,7 +103,7 @@ public class MongoDBProfilerTransport implements Transport {
         MongoClient mongoClient;
         try {
             if (configuration.getBoolean(CK_MONGO_USE_AUTH)) {
-                final MongoCredential credentials = MongoCredential.createMongoCRCredential(
+                final MongoCredential credentials = MongoCredential.createCredential(
                         configuration.getString(CK_MONGO_USER),
                         configuration.getString(CK_MONGO_DB),
                         configuration.getString(CK_MONGO_PW).toCharArray()


### PR DESCRIPTION
This change adds support for the newer MongoDB authentication schema (SCRAM-SHA-1), while retaining support for the older versions using MONGODB-CR. The Morphia library is updated to 0.111 to bring in the new static method needed for this.
