### PR TITLE
Upgrade to Graylog 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-mongodb-profiler</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -22,7 +22,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <graylog2.plugin-dir>/usr/share/graylog-server/plugin</graylog2.plugin-dir>
-        <graylog2.version>1.0.0</graylog2.version>
+        <graylog2.version>2.0.0</graylog2.version>
         <surefire.version>2.17</surefire.version>
         <jackson.version>2.4.2</jackson.version>
         <surefire.version>2.17</surefire.version>
@@ -31,7 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>org.graylog2</groupId>
-            <artifactId>graylog2-plugin</artifactId>
+            <artifactId>graylog2-server</artifactId>
             <version>${graylog2.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,8 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <graylog2.plugin-dir>/usr/share/graylog-server/plugin</graylog2.plugin-dir>
         <graylog2.version>2.0.0</graylog2.version>
-        <surefire.version>2.17</surefire.version>
-        <jackson.version>2.4.2</jackson.version>
-        <surefire.version>2.17</surefire.version>
+        <jackson.version>2.6.2</jackson.version>
+        <surefire.version>2.19.1</surefire.version>
     </properties>
 
     <dependencies>
@@ -53,7 +52,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.8.8</version>
+            <version>6.8.21</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/graylog2/inputs/mongoprofiler/input/InputVersion.java
+++ b/src/main/java/com/graylog2/inputs/mongoprofiler/input/InputVersion.java
@@ -7,7 +7,7 @@ import org.graylog2.plugin.Version;
  */
 public class InputVersion {
 
-    public static final Version PLUGIN_VERSION = new Version(1, 0, 1);
-    public static final Version REQUIRED_VERSION = new Version(1, 0, 0);
+    public static final Version PLUGIN_VERSION = new Version(1, 1, 0, "SNAPSHOT");
+    public static final Version REQUIRED_VERSION = new Version(2, 0, 0);
 
 }


### PR DESCRIPTION
As the changes involve updating Mongo Java Driver, and I'm not too familiar with it, I'd rather have someone reviewing the changes before pushing them out.

`MongoClient`'s `getConnection()` method was deprecated in version 2, and got removed in version 3. We were using it, I presume, to check if the `close()` method was closed. I couldn't find anything to replace it, even though [this thread](https://groups.google.com/forum/#!topic/mongodb-dev/33kv41HNTVc) was helpful. Instead, I am relying on an `AtomicBoolean` for that now.
